### PR TITLE
Solve use_amp compatability issue

### DIFF
--- a/huggingsound/trainer.py
+++ b/huggingsound/trainer.py
@@ -431,7 +431,7 @@ class CTCTrainer(Trainer):
         model.train()
         inputs = self._prepare_inputs(inputs)
 
-        if self.use_amp:
+        if (hasattr(self, 'use_amp') and self.use_amp) or (hasattr(self, 'use_cuda_amp') and self.use_cuda_amp):
             with torch.cuda.amp.autocast():
                 loss = self.compute_loss(model, inputs)
         else:
@@ -448,7 +448,7 @@ class CTCTrainer(Trainer):
         if self.args.gradient_accumulation_steps > 1:
             loss = loss / self.args.gradient_accumulation_steps
 
-        if self.use_amp:
+        if (hasattr(self, 'use_amp') and self.use_amp) or (hasattr(self, 'use_cuda_amp') and self.use_cuda_amp):
             self.scaler.scale(loss).backward()
         elif self.deepspeed:
             self.deepspeed.backward(loss)


### PR DESCRIPTION
`transformers` changed the name of the Trainer property use_amp to use_cuda_amp in this PR:
https://github.com/huggingface/transformers/pull/17138

As for now, calling the function `finetune()` with e.g. with `transformers==4.21.1` yields the following error:

> AttributeError: 'CTCTrainer' object has no attribute 'use_amp'


This PR aims to support both naming conventions and thus support both older and more recent versions of the `transformers` library 

Closes #45