### PR TITLE
Solved issue related to prediction padding and pad_token_id

### DIFF
--- a/huggingsound/trainer.py
+++ b/huggingsound/trainer.py
@@ -596,7 +596,9 @@ def finetune_ctc(model_name_or_path: str, output_dir: str, processor: Wav2Vec2Pr
                          evaluation_callbacks=training_args.evaluation_callbacks):
 
         pred_logits = pred.predictions
+        padding_mask = pred_logits[:,:,0] == -100
         pred_ids = np.argmax(pred_logits, axis=-1)
+        pred_ids[padding_mask] = processor.tokenizer.pad_token_id
 
         pred.label_ids[pred.label_ids == -100] = processor.tokenizer.pad_token_id
 


### PR DESCRIPTION
This is a relatively hidden bug and took me quite some time to debug :)

**Issue**
`_compute_metrics()` in the evaluation loop calculates wrong CER & WER metrics when using a TokenSet where the pad_token_id is not equal to 0. This doesn't affect the loss calculation / training as such, but the logged metrics during training will be wrong and won't match the metrics calculated using `model.evaluate()` after training. 

**Reason**
Similar to the `label_ids` the prediction logits are passed to `_compute_metrics()` as a matrix padded with -100 values.
Currently the `argmax` call which maps logits to token ids converts these `-100` values to `0`. So after the argmax, `pred_ids` will be 0-padded. For most wav2vec2 models this is not an issue, because their `vocab.json` assigns the ID 0 to the `<pad>` token. However, if you use a custom TokenSet for finetuning, `<pad>` will most probably not be mapped to 0, so the obtained "0-padding" values will wrongly correpond to another token.
<img width="173" alt="image" src="https://user-images.githubusercontent.com/36882833/188989318-70386213-f214-47f5-b324-fcb2a0f6dcb4.png">
See relevant code here: https://github.com/jonatasgrosman/huggingsound/blob/main/huggingsound/trainer.py#L599 

 ```python
pred_logits = pred.predictions
pred_ids = np.argmax(pred_logits, axis=-1)

pred.label_ids[pred.label_ids == -100] = processor.tokenizer.pad_token_id
```

**Proposed Solution**
Save a `padding_mask` which stores the location of the padded -100 in the prediction logits. Then after applying the `argmax` use the mask to set the padded entries to the ID corresponding to the padding token.